### PR TITLE
Use Local Volume

### DIFF
--- a/example-persistent-service/00-namespace.yml
+++ b/example-persistent-service/00-namespace.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-persistent-1

--- a/example-persistent-service/30-svn-service.yml
+++ b/example-persistent-service/30-svn-service.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svn
+  namespace: test-persistent-1
+spec:
+  ports:
+    - name: http
+      port: 80
+    - name: rweb
+      port: 9000
+  selector:
+    app: svn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rweb
+  namespace: test-persistent-1
+spec:
+  clusterIP: None
+  selector:
+    app: svn
+  ports:
+  - port: 9000
+    targetPort: 9000

--- a/example-persistent-service/35-svn.yml
+++ b/example-persistent-service/35-svn.yml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: svn
+  namespace: test-persistent-1
+spec:
+  serviceName: "svn"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: svn
+  template:
+    metadata:
+      labels:
+        app: svn
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: svn
+        image: solsson/rweb-httpd:1.7.3@sha256:dcc26dca1a52864ac1fbe94b8433b8af85768b9f24339342bc98e7f4d03ebb41
+        ports:
+        - name: http
+          containerPort: 80
+        env:
+        - name: AUTHN
+          value: anon
+        volumeMounts:
+        - name: datadir
+          mountPath: /svn
+      - name: rweb
+        image: solsson/rweb:1.7.3@sha256:94353fbcea1ea10304d42cc8cae85b33a9b6108a10988c3badada1649473584a
+        ports:
+        - name: rweb
+          containerPort: 9000
+        env:
+        - name: REPOS_DOWNLOAD_RULE
+          value: "|^/svn/[^/]+/(?!templates/).|"
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      #storageClassName: svn
+      # TODO each workload type should have its own storage class, but let's share the local-storage example now
+      storageClassName: local-storage
+      resources:
+        requests:
+          storage: 10Gi

--- a/example-persistent-service/svn-pvc.yml
+++ b/example-persistent-service/svn-pvc.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: datadir-svn-0
+  annotations:
+        "volume.alpha.kubernetes.io/node-affinity": '{
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    { "matchExpressions": [
+                        { "key": "kubernetes.io/hostname",
+                          "operator": "In",
+                          "values": ["yolean-k8s-1"]
+                        }
+                    ]}
+                 ]}
+              }'
+spec:
+    capacity:
+      storage: 10Gi
+    accessModes:
+    - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Retain
+    storageClassName: local-storage
+    local:
+      path: /mnt/local-storage/svn

--- a/example-persistent-service/svn-pvc_test-no-bind.yml
+++ b/example-persistent-service/svn-pvc_test-no-bind.yml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: datadir-svn-2
+  annotations:
+        "volume.alpha.kubernetes.io/node-affinity": '{
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    { "matchExpressions": [
+                        { "key": "kubernetes.io/hostname",
+                          "operator": "In",
+                          "values": ["yolean-k8s-1"]
+                        }
+                    ]}
+                 ]}
+              }'
+spec:
+    capacity:
+      storage: 10Gi
+    accessModes:
+    - ReadWriteOnce
+    persistentVolumeReclaimPolicy: Retain
+    storageClassName: local-storage
+    local:
+      path: /mnt/local-storage/should-not-bind-for-replica-0-or-1

--- a/kubeadm-master.yml
+++ b/kubeadm-master.yml
@@ -1,13 +1,25 @@
 apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
+token: #token#
+tokenTTL: 999999h
 api:
   advertiseAddress: 192.168.38.11
 networking:
+  # Flannel
   podSubnet: 10.244.0.0/16
-apiServerExtraArgs:
-  service-node-port-range: 80-32767
-token: #token#
-tokenTTL: 999999h
 featureGates:
   #SelfHosting: true
   #HighAvailability: true
+  #PersistentLocalVolumes: true
+  #VolumeScheduling: true
+  #MountPropagation: true
+apiServerExtraArgs:
+  # https://kubernetes.io/docs/reference/generated/kube-apiserver/
+  service-node-port-range: 80-32767
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
+controllerManagerExtraArgs:
+  # https://kubernetes.io/docs/reference/generated/kube-controller-manager/
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
+schedulerExtraArgs:
+  # https://kubernetes.io/docs/reference/generated/kube-scheduler/
+  feature-gates: "PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"

--- a/local-volume/storageclass_local-storage.yaml
+++ b/local-volume/storageclass_local-storage.yaml
@@ -1,0 +1,7 @@
+# Only create this for K8s 1.9+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/setup.sh
+++ b/setup.sh
@@ -7,8 +7,6 @@ NODE_IP=$1
 CLUSTER_TOKEN=$2
 [ -z "$CLUSTER_TOKEN" ] && echo "Second argument must be the cluster init/join token"
 
-export KUBE_FEATURE_GATES="PersistentLocalVolumes=true,VolumeScheduling=true,MountPropagation=true"
-
 ### Try to align networking with k8s + flannel assumptions
 
 getent hosts $NODE_IP | grep $NODE_IP | grep $HOSTNAME || {


### PR DESCRIPTION
Actually https://kubernetes.io/docs/concepts/storage/volumes/#local is all you need, together with how to add `feature-gates` in all three places in kubeadm conf. Volumes docs link to https://github.com/kubernetes-incubator/external-storage/tree/master/local-volume but the scope there is a lot bigger than making the scheduler aware of on which node a PV can run.